### PR TITLE
fix: Liveness probe must not start rbac-manager

### DIFF
--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -166,7 +166,7 @@ spec:
             command:
               - sh
               - -c
-              - ps -ef | rbac-manager
+              - ps -ef | grep rbac-manager
           initialDelaySeconds: 5
           periodSeconds: 5
         readinessProbe:


### PR DESCRIPTION
This update fix the memory leak issue rised in #58 

The issue #58 will be updated with comments.