### PR TITLE
fix: Deployment shouldn't pull image each time

### DIFF
--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -159,7 +159,7 @@ spec:
       containers:
       - name: rbac-manager
         image: "quay.io/reactiveops/rbac-manager:0.7.0"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         # these liveness probes are not very helpful yet
         livenessProbe:
           exec:


### PR DESCRIPTION
This pull request change the fact that deployment pull image even if the tag is fixed.