### PR TITLE
Fix #68

### DIFF
--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -158,23 +158,9 @@ spec:
       serviceAccountName: rbac-manager
       containers:
       - name: rbac-manager
-        image: "quay.io/reactiveops/rbac-manager:0.7.0"
+        image: "quay.io/reactiveops/rbac-manager:0.8.1"
         imagePullPolicy: Always
         # these liveness probes are not very helpful yet
-        livenessProbe:
-          exec:
-            command:
-              - sh
-              - -c
-              - ps -ef | grep rbac-manager
-          initialDelaySeconds: 5
-          periodSeconds: 5
-        readinessProbe:
-          exec:
-            command:
-              - sh
-              - -c
-              - ps -ef | grep rbac-manager
         securityContext:
           runAsUser: 1200
           allowPrivilegeEscalation: false


### PR DESCRIPTION
Remove liveness and readiness probes that don't work now that we use scratch image.  
Update deploy yaml for pending 0.8.1 release