### PR TITLE
Updated Deployment API version and updated rbac manager image from 0.8.1 to 0.8.3

### DIFF
--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -136,7 +136,7 @@ spec:
       type: object
   version: v1beta1
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rbac-manager
@@ -158,7 +158,7 @@ spec:
       serviceAccountName: rbac-manager
       containers:
       - name: rbac-manager
-        image: "quay.io/reactiveops/rbac-manager:0.8.1"
+        image: "quay.io/reactiveops/rbac-manager:0.8.3"
         imagePullPolicy: Always
         # these liveness probes are not very helpful yet
         securityContext:


### PR DESCRIPTION
Updated the Deployment API version so that the deployment works "out of the box" on K8s 1.16 + changed rbac-manager image to the latest release (0.8.3).

API version extensions/v1beta1 is no longer supported by default in Kubernetes 1.16.