### PR TITLE
Add metric endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tmp
 .vscode
 
 coverage.txt
+cover-report.html

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -714,16 +714,19 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "k8s.io/api/core/v1",
     "k8s.io/api/rbac/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
-    "k8s.io/apimachinery/pkg/labels",
     "k8s.io/apimachinery/pkg/runtime",
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/runtime/serializer",
+    "k8s.io/apimachinery/pkg/util/runtime",
+    "k8s.io/apimachinery/pkg/watch",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/fake",
     "k8s.io/client-go/kubernetes/scheme",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,7 @@
 [[constraint]]
   name = "sigs.k8s.io/controller-runtime"
   version = "v0.1.10"
+
+[[constraint]]
+  name = "github.com/prometheus/client_golang"
+  version = "0.9.2"

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -91,12 +91,14 @@ func main() {
 	watcher.WatchRelatedResources()
 
 	// Start metrics endpoint
-	metrics.RegisterMetrics()
-	http.Handle("/metrics", promhttp.Handler())
-	if err := http.ListenAndServe(*addr, nil); err != nil {
-		logrus.Error(err, "unable to serve the metrics endpoint")
-		os.Exit(1)
-	}
+	go func() {
+		metrics.RegisterMetrics()
+		http.Handle("/metrics", promhttp.Handler())
+		if err := http.ListenAndServe(*addr, nil); err != nil {
+			logrus.Error(err, "unable to serve the metrics endpoint")
+			os.Exit(1)
+		}
+	}()
 
 	// Start the Cmd
 	logrus.Info("Watching RBAC Definitions")

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,8 @@ package main
 
 import (
 	"flag"
+	"github.com/fairwindsops/rbac-manager/pkg/metrics"
+	"net/http"
 	"os"
 
 	"github.com/fairwindsops/rbac-manager/pkg/apis"
@@ -25,7 +27,9 @@ import (
 	"github.com/fairwindsops/rbac-manager/pkg/watcher"
 	"github.com/fairwindsops/rbac-manager/version"
 
-	logrus "github.com/sirupsen/logrus"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+
+	"github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -33,6 +37,7 @@ import (
 )
 
 var logLevel = flag.String("log-level", logrus.InfoLevel.String(), "Logrus log level")
+var addr = flag.String("metrics-address", ":8080", "The address to serve prometheus metrics.")
 
 func main() {
 	flag.Parse()
@@ -84,6 +89,14 @@ func main() {
 	// Watch Related Resources
 	logrus.Info("Watching resources related to RBAC Definitions")
 	watcher.WatchRelatedResources()
+
+	// Start metrics endpoint
+	metrics.RegisterMetrics()
+	http.Handle("/metrics", promhttp.Handler())
+	if err := http.ListenAndServe(*addr, nil); err != nil {
+		logrus.Error(err, "unable to serve the metrics endpoint")
+		os.Exit(1)
+	}
 
 	// Start the Cmd
 	logrus.Info("Watching RBAC Definitions")

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -160,7 +160,25 @@ spec:
       - name: rbac-manager
         image: "quay.io/reactiveops/rbac-manager:0.8.3"
         imagePullPolicy: Always
-        # these liveness probes are not very helpful yet
+        # these liveness probes use the metrics endpoint
+        readinessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 3
+          failureThreshold: 3
+        livenessProbe:
+          httpGet:
+            scheme: HTTP
+            path: /metrics
+            port: 8080
+          initialDelaySeconds: 5
+          timeoutSeconds: 3
+          periodSeconds: 10
+          failureThreshold: 3
         securityContext:
           runAsUser: 1200
           allowPrivilegeEscalation: false
@@ -177,3 +195,8 @@ spec:
           requests:
             cpu: 100m
             memory: 128Mi
+        ports:
+          # metrics port
+          - name: http-metrics
+            containerPort: 8080
+            protocol: TCP

--- a/pkg/controller/namespace.go
+++ b/pkg/controller/namespace.go
@@ -16,6 +16,7 @@ package controller
 import (
 	"context"
 	"github.com/fairwindsops/rbac-manager/pkg/kube"
+	"github.com/fairwindsops/rbac-manager/pkg/metrics"
 
 	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
 	"github.com/fairwindsops/rbac-manager/pkg/reconciler"
@@ -71,6 +72,7 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 }
 
 func reconcileNamespace(config *rest.Config, namespace *v1.Namespace) error {
+	metrics.ReconcileCounter.WithLabelValues("namespace").Inc()
 	var err error
 	var rbacDefList rbacmanagerv1beta1.RBACDefinitionList
 	rdr := reconciler.Reconciler{}

--- a/pkg/controller/namespace.go
+++ b/pkg/controller/namespace.go
@@ -55,11 +55,13 @@ func (r *ReconcileNamespace) Reconcile(request reconcile.Request) (reconcile.Res
 		if errors.IsNotFound(err) {
 			err = reconcileNamespace(r.config, namespace)
 			if err != nil {
+				metrics.ErrorCounter.Inc()
 				return reconcile.Result{}, err
 			}
 			return reconcile.Result{}, nil
 		}
 		// Error reading the object - requeue the request.
+		metrics.ErrorCounter.Inc()
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/rbacdefinition.go
+++ b/pkg/controller/rbacdefinition.go
@@ -18,6 +18,7 @@ package controller
 
 import (
 	"context"
+	"github.com/fairwindsops/rbac-manager/pkg/metrics"
 
 	"github.com/fairwindsops/rbac-manager/pkg/reconciler"
 
@@ -62,6 +63,7 @@ func (r *ReconcileRBACDefinition) Reconcile(request reconcile.Request) (reconcil
 	rbacDef := &rbacmanagerv1beta1.RBACDefinition{}
 	err = r.Get(context.TODO(), request.NamespacedName, rbacDef)
 	if err != nil {
+		metrics.ErrorCounter.Inc()
 		if errors.IsNotFound(err) {
 			// Object not found, return.  Created objects are automatically garbage collected.
 			// For additional cleanup logic use finalizers.
@@ -71,7 +73,10 @@ func (r *ReconcileRBACDefinition) Reconcile(request reconcile.Request) (reconcil
 		return reconcile.Result{}, err
 	}
 
-	rdr.Reconcile(rbacDef)
+	err = rdr.Reconcile(rbacDef)
+	if err != nil {
+		metrics.ErrorCounter.Inc()
+	}
 
 	return reconcile.Result{}, nil
 }

--- a/pkg/controller/rbacdefinition.go
+++ b/pkg/controller/rbacdefinition.go
@@ -56,6 +56,7 @@ type ReconcileRBACDefinition struct {
 
 // Reconcile makes changes in response to RBACDefinition changes
 func (r *ReconcileRBACDefinition) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	metrics.ReconcileCounter.WithLabelValues("rbacdefinition").Inc()
 	var err error
 	rdr := reconciler.Reconciler{Clientset: r.clientset}
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -23,6 +23,7 @@ import (
 const namespace = "rbacmanager"
 
 var (
+	// ErrorCounter is a global counter for errors
 	ErrorCounter = prometheus.NewCounter(
 		prometheus.CounterOpts{
 			Namespace: namespace,
@@ -30,6 +31,7 @@ var (
 			Help:      "Number of errors while reconciling",
 		})
 
+	// ChangeCounter counts kubernetes events (e.g. create, delete) on objects (e.g. ClusterRoleBinding)
 	ChangeCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,
@@ -40,6 +42,7 @@ var (
 	)
 )
 
+// RegisterMetrics must be called exactly once and registers the prometheus counters as metrics
 func RegisterMetrics() {
 	prometheus.MustRegister(ErrorCounter)
 	prometheus.MustRegister(ChangeCounter)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -46,5 +46,4 @@ var (
 func RegisterMetrics() {
 	prometheus.MustRegister(ErrorCounter)
 	prometheus.MustRegister(ChangeCounter)
-	prometheus.MustRegister(prometheus.NewGoCollector())
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -41,6 +41,7 @@ var (
 		[]string{"object", "action"},
 	)
 
+	// ReconcileCounter counts controllers invocations
 	ReconcileCounter = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
 			Namespace: namespace,

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -40,10 +40,20 @@ var (
 		},
 		[]string{"object", "action"},
 	)
+
+	ReconcileCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "reconcile_total",
+			Help:      "Number of times a reconciling is triggered",
+		},
+		[]string{"controller"},
+	)
 )
 
 // RegisterMetrics must be called exactly once and registers the prometheus counters as metrics
 func RegisterMetrics() {
 	prometheus.MustRegister(ErrorCounter)
 	prometheus.MustRegister(ChangeCounter)
+	prometheus.MustRegister(ReconcileCounter)
 }

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 FairwindsOps Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+const namespace = "rbacmanager"
+
+var (
+	ErrorCounter = prometheus.NewCounter(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "errors_total",
+			Help:      "Number of errors while reconciling",
+		})
+
+	ChangeCounter = prometheus.NewCounterVec(
+		prometheus.CounterOpts{
+			Namespace: namespace,
+			Name:      "changed_total",
+			Help:      "Number of times a Kubernetes object is created or deleted by the rbac-manager",
+		},
+		[]string{"object", "action"},
+	)
+)
+
+func RegisterMetrics() {
+	prometheus.MustRegister(ErrorCounter)
+	prometheus.MustRegister(ChangeCounter)
+	prometheus.MustRegister(prometheus.NewGoCollector())
+}

--- a/pkg/metrics/metrics_test.go
+++ b/pkg/metrics/metrics_test.go
@@ -1,0 +1,10 @@
+package metrics
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestRegisterMetrics(t *testing.T) {
+	assert.NotPanics(t, RegisterMetrics)
+}

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -182,6 +182,8 @@ func (r *Reconciler) reconcileServiceAccounts(requested *[]v1.ServiceAccount) er
 				if err != nil {
 					logrus.Infof("Error deleting Service Account: %v", err)
 					metrics.ErrorCounter.Inc()
+				} else {
+					metrics.ChangeCounter.WithLabelValues("serviceaccounts", "delete").Inc()
 				}
 			} else {
 				logrus.Debugf("Matches requested Service Account %v", existingSA.Name)

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -15,6 +15,7 @@
 package reconciler
 
 import (
+	"github.com/fairwindsops/rbac-manager/pkg/metrics"
 	"reflect"
 	"sync"
 
@@ -180,6 +181,7 @@ func (r *Reconciler) reconcileServiceAccounts(requested *[]v1.ServiceAccount) er
 				err := r.Clientset.CoreV1().ServiceAccounts(existingSA.Namespace).Delete(existingSA.Name, &metav1.DeleteOptions{})
 				if err != nil {
 					logrus.Infof("Error deleting Service Account: %v", err)
+					metrics.ErrorCounter.Inc()
 				}
 			} else {
 				logrus.Debugf("Matches requested Service Account %v", existingSA.Name)
@@ -192,6 +194,9 @@ func (r *Reconciler) reconcileServiceAccounts(requested *[]v1.ServiceAccount) er
 		_, err := r.Clientset.CoreV1().ServiceAccounts(serviceAccountToCreate.ObjectMeta.Namespace).Create(&serviceAccountToCreate)
 		if err != nil {
 			logrus.Errorf("Error creating Service Account: %v", err)
+			metrics.ErrorCounter.Inc()
+		} else {
+			metrics.ChangeCounter.WithLabelValues("serviceaccounts", "create").Inc()
 		}
 	}
 
@@ -201,6 +206,7 @@ func (r *Reconciler) reconcileServiceAccounts(requested *[]v1.ServiceAccount) er
 func (r *Reconciler) reconcileClusterRoleBindings(requested *[]rbacv1.ClusterRoleBinding) error {
 	existing, err := r.Clientset.RbacV1().ClusterRoleBindings().List(kube.ListOptions)
 	if err != nil {
+		metrics.ErrorCounter.Inc()
 		return err
 	}
 
@@ -239,6 +245,9 @@ func (r *Reconciler) reconcileClusterRoleBindings(requested *[]rbacv1.ClusterRol
 				err := r.Clientset.RbacV1().ClusterRoleBindings().Delete(existingCRB.Name, &metav1.DeleteOptions{})
 				if err != nil {
 					logrus.Errorf("Error deleting Cluster Role Binding: %v", err)
+					metrics.ErrorCounter.Inc()
+				} else {
+					metrics.ChangeCounter.WithLabelValues("clusterrolebindings", "delete").Inc()
 				}
 			} else {
 				logrus.Debugf("Matches requested Cluster Role Binding: %v", existingCRB.Name)
@@ -251,6 +260,9 @@ func (r *Reconciler) reconcileClusterRoleBindings(requested *[]rbacv1.ClusterRol
 		_, err := r.Clientset.RbacV1().ClusterRoleBindings().Create(&clusterRoleBindingToCreate)
 		if err != nil {
 			logrus.Errorf("Error creating Cluster Role Binding: %v", err)
+			metrics.ErrorCounter.Inc()
+		} else {
+			metrics.ChangeCounter.WithLabelValues("clusterrolebindings", "create").Inc()
 		}
 	}
 
@@ -298,6 +310,9 @@ func (r *Reconciler) reconcileRoleBindings(requested *[]rbacv1.RoleBinding) erro
 				err := r.Clientset.RbacV1().RoleBindings(existingRB.Namespace).Delete(existingRB.Name, &metav1.DeleteOptions{})
 				if err != nil {
 					logrus.Infof("Error deleting Role Binding: %v", err)
+					metrics.ErrorCounter.Inc()
+				} else {
+					metrics.ChangeCounter.WithLabelValues("rolebindings", "delete").Inc()
 				}
 			} else {
 				logrus.Debugf("Matches requested Role Binding %v", existingRB.Name)
@@ -310,6 +325,9 @@ func (r *Reconciler) reconcileRoleBindings(requested *[]rbacv1.RoleBinding) erro
 		_, err := r.Clientset.RbacV1().RoleBindings(roleBindingToCreate.ObjectMeta.Namespace).Create(&roleBindingToCreate)
 		if err != nil {
 			logrus.Errorf("Error creating Role Binding: %v", err)
+			metrics.ErrorCounter.Inc()
+		} else {
+			metrics.ChangeCounter.WithLabelValues("rolebindings", "create").Inc()
 		}
 	}
 


### PR DESCRIPTION
This adds a prometheus metrics endpoint which exposes some metrics like error counters and reconcile counters.

This fixes https://github.com/FairwindsOps/rbac-manager/issues/70.
