### PR TITLE
Making the build actually trigger on PRs now that it doesn't need to …

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,9 +57,6 @@ workflows:
       - test
       - build:
           context: org-global
-          filters:
-            tags:
-              only: /^testing-.*/
   release:
     jobs:
       - release:


### PR DESCRIPTION
…push on external ones.