### PR TITLE
Fix Import path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
     docker:
       - image: circleci/golang:1.12
 
-    working_directory: /go/src/github.com/fairwindsops/rbac-manager
+    working_directory: /go/src/github.com/FairwindsOps/rbac-manager
 
     steps:
       - checkout
@@ -48,7 +48,6 @@ jobs:
       - setup_remote_docker
       - run: echo 'export DOCKER_BASE_TAG=$CIRCLE_TAG' >> $BASH_ENV
       - *docker_build_and_push
-
 
 workflows:
   version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM golang:1.12 AS build-env
-WORKDIR /go/src/github.com/fairwindsops/rbac-manager/
+WORKDIR /go/src/github.com/FairwindsOps/rbac-manager/
 
 COPY . .
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -a -o rbac-manager ./cmd/manager/main.go
@@ -15,7 +15,7 @@ COPY --from=alpine /etc/passwd /etc/passwd
 
 
 USER nobody
-COPY --from=build-env /go/src/github.com/fairwindsops/rbac-manager/rbac-manager /
+COPY --from=build-env /go/src/github.com/FairwindsOps/rbac-manager/rbac-manager /
 
 ENTRYPOINT ["/rbac-manager"]
 CMD ["--log-level=info"]

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -20,10 +20,10 @@ import (
 	"flag"
 	"os"
 
-	"github.com/fairwindsops/rbac-manager/pkg/apis"
-	"github.com/fairwindsops/rbac-manager/pkg/controller"
-	"github.com/fairwindsops/rbac-manager/pkg/watcher"
-	"github.com/fairwindsops/rbac-manager/version"
+	"github.com/FairwindsOps/rbac-manager/pkg/apis"
+	"github.com/FairwindsOps/rbac-manager/pkg/controller"
+	"github.com/FairwindsOps/rbac-manager/pkg/watcher"
+	"github.com/FairwindsOps/rbac-manager/version"
 
 	logrus "github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"

--- a/pkg/apis/addtoscheme_rbacmanager_v1beta1.go
+++ b/pkg/apis/addtoscheme_rbacmanager_v1beta1.go
@@ -17,7 +17,7 @@ limitations under the License.
 package apis
 
 import (
-	"github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	"github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
 )
 
 func init() {

--- a/pkg/controller/namespace.go
+++ b/pkg/controller/namespace.go
@@ -15,10 +15,10 @@ package controller
 
 import (
 	"context"
-	"github.com/fairwindsops/rbac-manager/pkg/kube"
+	"github.com/FairwindsOps/rbac-manager/pkg/kube"
 
-	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
-	"github.com/fairwindsops/rbac-manager/pkg/reconciler"
+	rbacmanagerv1beta1 "github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	"github.com/FairwindsOps/rbac-manager/pkg/reconciler"
 
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"

--- a/pkg/controller/rbacdefinition.go
+++ b/pkg/controller/rbacdefinition.go
@@ -19,9 +19,9 @@ package controller
 import (
 	"context"
 
-	"github.com/fairwindsops/rbac-manager/pkg/reconciler"
+	"github.com/FairwindsOps/rbac-manager/pkg/reconciler"
 
-	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	rbacmanagerv1beta1 "github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"

--- a/pkg/controller/shared.go
+++ b/pkg/controller/shared.go
@@ -17,7 +17,7 @@ limitations under the License.
 package controller
 
 import (
-	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	rbacmanagerv1beta1 "github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"

--- a/pkg/kube/rbacdefinitions.go
+++ b/pkg/kube/rbacdefinitions.go
@@ -17,7 +17,7 @@ limitations under the License.
 package kube
 
 import (
-	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	rbacmanagerv1beta1 "github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"

--- a/pkg/reconciler/matcher_test.go
+++ b/pkg/reconciler/matcher_test.go
@@ -17,7 +17,7 @@ package reconciler
 import (
 	"testing"
 
-	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	rbacmanagerv1beta1 "github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"

--- a/pkg/reconciler/parser.go
+++ b/pkg/reconciler/parser.go
@@ -18,8 +18,8 @@ import (
 	"errors"
 	"fmt"
 
-	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
-	"github.com/fairwindsops/rbac-manager/pkg/kube"
+	rbacmanagerv1beta1 "github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	"github.com/FairwindsOps/rbac-manager/pkg/kube"
 	logrus "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/pkg/reconciler/parser_test.go
+++ b/pkg/reconciler/parser_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	rbacmanagerv1beta1 "github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -18,9 +18,9 @@ import (
 	"reflect"
 	"sync"
 
-	"github.com/fairwindsops/rbac-manager/pkg/kube"
+	"github.com/FairwindsOps/rbac-manager/pkg/kube"
 
-	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	rbacmanagerv1beta1 "github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
 	logrus "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/pkg/reconciler/reconciler_test.go
+++ b/pkg/reconciler/reconciler_test.go
@@ -19,8 +19,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
-	"github.com/fairwindsops/rbac-manager/pkg/kube"
+	rbacmanagerv1beta1 "github.com/FairwindsOps/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	"github.com/FairwindsOps/rbac-manager/pkg/kube"
 
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/pkg/watcher/clusterrolebinding.go
+++ b/pkg/watcher/clusterrolebinding.go
@@ -17,8 +17,8 @@ limitations under the License.
 package watcher
 
 import (
-	kube "github.com/fairwindsops/rbac-manager/pkg/kube"
-	"github.com/fairwindsops/rbac-manager/pkg/reconciler"
+	kube "github.com/FairwindsOps/rbac-manager/pkg/kube"
+	"github.com/FairwindsOps/rbac-manager/pkg/reconciler"
 	"github.com/sirupsen/logrus"
 
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/pkg/watcher/rolebinding.go
+++ b/pkg/watcher/rolebinding.go
@@ -17,8 +17,8 @@ limitations under the License.
 package watcher
 
 import (
-	kube "github.com/fairwindsops/rbac-manager/pkg/kube"
-	"github.com/fairwindsops/rbac-manager/pkg/reconciler"
+	kube "github.com/FairwindsOps/rbac-manager/pkg/kube"
+	"github.com/FairwindsOps/rbac-manager/pkg/reconciler"
 	"github.com/sirupsen/logrus"
 
 	rbacv1 "k8s.io/api/rbac/v1"

--- a/pkg/watcher/serviceaccount.go
+++ b/pkg/watcher/serviceaccount.go
@@ -17,8 +17,8 @@ limitations under the License.
 package watcher
 
 import (
-	kube "github.com/fairwindsops/rbac-manager/pkg/kube"
-	"github.com/fairwindsops/rbac-manager/pkg/reconciler"
+	kube "github.com/FairwindsOps/rbac-manager/pkg/kube"
+	"github.com/FairwindsOps/rbac-manager/pkg/reconciler"
 	"github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"

--- a/pkg/watcher/shared.go
+++ b/pkg/watcher/shared.go
@@ -17,7 +17,7 @@ limitations under the License.
 package watcher
 
 import (
-	kube "github.com/fairwindsops/rbac-manager/pkg/kube"
+	kube "github.com/FairwindsOps/rbac-manager/pkg/kube"
 )
 
 // WatchRelatedResources watches all resources owned by RBAC Definitions


### PR DESCRIPTION
To avoid `case-insensitive import collision` which will raise when linting with go 1.13
Signed-off-by: Guus van Weelden <guus.vanweelden@moia.io>