### PR TITLE
Add e2e test to circleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rok8s-scripts: fairwinds/rok8s-scripts@9.2.0
+  rok8s-scripts: fairwinds/rok8s-scripts@9.4.0
 
 references:
   docker_build_and_push: &docker_build_and_push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,7 @@
-version: 2
+version: 2.1
+
+orbs:
+  rok8s-scripts: fairwinds/rok8s-scripts@9.2.0
 
 references:
   docker_build_and_push: &docker_build_and_push
@@ -57,6 +60,17 @@ workflows:
       - test
       - build:
           context: org-global
+      - rok8s-scripts/kubernetes_e2e_tests:
+          pre_script: e2e/pre.sh
+          script: e2e/test.sh
+          requires:
+            - test
+            - build
+          filters:
+            branches:
+              only: /.*/
+            tags:
+              ignore: /v.*/
   release:
     jobs:
       - release:

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -20,35 +21,35 @@ metadata:
   labels:
     app: rbac-manager
 rules:
-- apiGroups:
-  - rbacmanager.reactiveops.io
-  resources:
-  - rbacdefinitions
-  verbs:
-  - get
-  - list
-  - watch
-- apiGroups:
-  - rbac.authorization.k8s.io
-  - authorization.k8s.io
-  resources:
-  - '*'
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - serviceaccounts
-  verbs:
-  - '*'
-- apiGroups:
-  - ""
-  resources:
-  - namespaces
-  verbs:
-  - get
-  - list
-  - watch
+  - apiGroups:
+      - rbacmanager.reactiveops.io
+    resources:
+      - rbacdefinitions
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - rbac.authorization.k8s.io
+      - authorization.k8s.io
+    resources:
+      - '*'
+    verbs:
+      - '*'
+  - apiGroups:
+      - "" # core
+    resources:
+      - serviceaccounts
+    verbs:
+      - '*'
+  - apiGroups:
+      - "" # core
+    resources:
+      - namespaces
+    verbs:
+      - get
+      - list
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -61,9 +62,9 @@ roleRef:
   kind: ClusterRole
   name: rbac-manager
 subjects:
-- kind: ServiceAccount
-  name: rbac-manager
-  namespace: rbac-manager
+  - kind: ServiceAccount
+    name: rbac-manager
+    namespace: "rbac-manager"
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -159,6 +160,7 @@ spec:
       - name: rbac-manager
         image: "quay.io/reactiveops/rbac-manager:0.8.4"
         imagePullPolicy: Always
+        # these liveness probes use the metrics endpoint
         readinessProbe:
           httpGet:
             scheme: HTTP
@@ -185,7 +187,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-            - ALL
+              - ALL
         resources:
           limits:
             cpu: 100m
@@ -194,6 +196,7 @@ spec:
             cpu: 100m
             memory: 128Mi
         ports:
-        - name: http-metrics
-          containerPort: 8080
-          protocol: TCP
+          # metrics port
+          - name: http-metrics
+            containerPort: 8080
+            protocol: TCP

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -1,4 +1,3 @@
----
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -21,35 +20,35 @@ metadata:
   labels:
     app: rbac-manager
 rules:
-  - apiGroups:
-      - rbacmanager.reactiveops.io
-    resources:
-      - rbacdefinitions
-    verbs:
-      - get
-      - list
-      - watch
-  - apiGroups:
-      - rbac.authorization.k8s.io
-      - authorization.k8s.io
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - apiGroups:
-      - "" # core
-    resources:
-      - serviceaccounts
-    verbs:
-      - '*'
-  - apiGroups:
-      - "" # core
-    resources:
-      - namespaces
-    verbs:
-      - get
-      - list
-      - watch
+- apiGroups:
+  - rbacmanager.reactiveops.io
+  resources:
+  - rbacdefinitions
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - rbac.authorization.k8s.io
+  - authorization.k8s.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRoleBinding
@@ -62,9 +61,9 @@ roleRef:
   kind: ClusterRole
   name: rbac-manager
 subjects:
-  - kind: ServiceAccount
-    name: rbac-manager
-    namespace: "rbac-manager"
+- kind: ServiceAccount
+  name: rbac-manager
+  namespace: rbac-manager
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
 kind: CustomResourceDefinition
@@ -158,9 +157,8 @@ spec:
       serviceAccountName: rbac-manager
       containers:
       - name: rbac-manager
-        image: "quay.io/reactiveops/rbac-manager:0.8.3"
+        image: "quay.io/reactiveops/rbac-manager:0.8.4"
         imagePullPolicy: Always
-        # these liveness probes use the metrics endpoint
         readinessProbe:
           httpGet:
             scheme: HTTP
@@ -187,7 +185,7 @@ spec:
           runAsNonRoot: true
           capabilities:
             drop:
-              - ALL
+            - ALL
         resources:
           limits:
             cpu: 100m
@@ -196,7 +194,6 @@ spec:
             cpu: 100m
             memory: 128Mi
         ports:
-          # metrics port
-          - name: http-metrics
-            containerPort: 8080
-            protocol: TCP
+        - name: http-metrics
+          containerPort: 8080
+          protocol: TCP

--- a/e2e/pre.sh
+++ b/e2e/pre.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+
+wget -O /usr/local/bin/yq "https://github.com/mikefarah/yq/releases/download/2.4.0/yq_linux_amd64"
+chmod +x /usr/local/bin/yq
+
+if [ -z "$CI_SHA1" ]; then
+    echo "CI_SHA1 not set. Something is wrong"
+    exit 1
+else
+    echo "CI_SHA1: $CI_SHA1"
+fi
+
+yq w -d5 -i deploy/all.yaml 'spec.template.spec.containers[0].image' "quay.io/reactiveops/rbac-manager:dev-$CI_SHA1"
+cat deploy/all.yaml
+
+docker cp deploy e2e-command-runner:/

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -43,5 +43,13 @@ rbacBindings:
       - clusterRole: test-rbac-manager
 EOF
 
-sleep 10
+# wait up to 2 minutes for rbac-manager to create the binding
+counter=0
+until kubectl get clusterrolebinding/rbac-manager-definition-admins-test-rbac-manager; do
+  let "counter=counter+1"
+  sleep 10
+  if [ $counter -gt 11 ]; then
+    break
+  fi
+done
 kubectl auth can-i create deployments --as=system:serviceaccount:rbac-manager:test-rbac-manager

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -43,4 +43,5 @@ rbacBindings:
       - clusterRole: test-rbac-manager
 EOF
 
+sleep 10
 kubectl auth can-i create deployments --as=system:serviceaccount:rbac-manager:test-rbac-manager

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+
+
+printf "\n\n"
+echo "**************************"
+echo "** Begin E2E Test Setup **"
+echo "**************************"
+printf "\n\n"
+
+set -e
+
+
+printf "\n\n"
+echo "********************************************************************"
+echo "** Install rbac-manager at $CI_SHA1 **"
+echo "********************************************************************"
+printf "\n\n"
+
+kubectl apply -f deploy/all.yaml
+kubectl -n rbac-manager wait deployment/rbac-manager --timeout=120s --for condition=available
+
+
+printf "\n\n"
+echo "********************************************************************"
+echo "** Test rbacDefinition **"
+echo "********************************************************************"
+printf "\n\n"
+kubectl create serviceaccount -n rbac-manager test-rbac-manager
+kubectl create clusterrole test-rbac-manager --verb="*" --resource=deployment
+
+cat <<EOF | kubectl create -f -
+apiVersion: rbacmanager.reactiveops.io/v1beta1
+kind: RBACDefinition
+metadata:
+  name: rbac-manager-definition
+rbacBindings:
+  - name: admins
+    subjects:
+      - kind: ServiceAccount
+        name: test-rbac-manager
+        namespace: rbac-manager
+    clusterRoleBindings:
+      - clusterRole: test-rbac-manager
+EOF
+
+kubectl auth can-i create deployments --as=system:serviceaccount:rbac-manager:test-rbac-manager

--- a/e2e/test.sh
+++ b/e2e/test.sh
@@ -26,8 +26,7 @@ echo "********************************************************************"
 echo "** Test rbacDefinition **"
 echo "********************************************************************"
 printf "\n\n"
-kubectl create serviceaccount -n rbac-manager test-rbac-manager
-kubectl create clusterrole test-rbac-manager --verb="*" --resource=deployment
+kubectl create clusterrole test-rbac-manager --verb="create" --resource=deployment
 
 cat <<EOF | kubectl create -f -
 apiVersion: rbacmanager.reactiveops.io/v1beta1


### PR DESCRIPTION
This PR adds an e2e test workflow in the circleci config.  The workflow will:

* provision a KIND cluster
* install rbac-manager using the image `quay.io/reactiveops/rbac-manager:dev-$CI_SHA1`
* apply an RbacDefinition for a new serviceaccount and verify the permissions.