### PR TITLE
Automatic put current github tag as rbac-manager version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ references:
     run:
       name: Docker login, build, and push
       command: |
-        docker build -f Dockerfile -t quay.io/reactiveops/rbac-manager:$DOCKER_BASE_TAG .
+        docker build --build-arg "VERSION=$DOCKER_BASE_TAG" -f Dockerfile -t quay.io/reactiveops/rbac-manager:$DOCKER_BASE_TAG .
 
         if [[ -z $CIRCLE_PR_NUMBER ]]; then
           bash <(curl -s https://codecov.io/bash)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM golang:1.12 AS build-env
 WORKDIR /go/src/github.com/fairwindsops/rbac-manager/
 
+ARG VERSION=dev
+
 COPY . .
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -a -o rbac-manager ./cmd/manager/main.go
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -ldflags="-w -s -X github.com/fairwindsops/rbac-manager/version.Version=$VERSION" -a -o rbac-manager ./cmd/manager/main.go
 
 FROM alpine:3.9 AS alpine
 RUN apk update && apk add --no-cache git ca-certificates tzdata && update-ca-certificates

--- a/version/version.go
+++ b/version/version.go
@@ -16,5 +16,5 @@ package version
 
 var (
 	// Version represents the current version of RBAC Manager
-	Version = "0.8.3"
+	Version = "VERSION"
 )


### PR DESCRIPTION
In rbac-manager 0.8.4 i found that application version still 0.8.3. There some improvement to exclude manual version bumping in version/version.go file.