### PR TITLE
initializing klog flags (fix for #104)

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -18,6 +18,9 @@ package main
 
 import (
 	"flag"
+
+	"k8s.io/klog"
+
 	"github.com/fairwindsops/rbac-manager/pkg/metrics"
 	"net/http"
 	"os"
@@ -38,6 +41,10 @@ import (
 
 var logLevel = flag.String("log-level", logrus.InfoLevel.String(), "Logrus log level")
 var addr = flag.String("metrics-address", ":8080", "The address to serve prometheus metrics.")
+
+func init() {
+	klog.InitFlags(nil)
+}
 
 func main() {
 	flag.Parse()


### PR DESCRIPTION
fixes #104

By simply initializing the klog flags, we send their default configuration to any dependency that uses it, which includes logging to stderr instead of a file.