### PR TITLE
using numeric user in Dockerfile for PSP

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 FROM golang:1.13 AS build-env
 WORKDIR /go/src/github.com/fairwindsops/rbac-manager/
+RUN useradd -u 9999 rbacman
 
 ARG VERSION=dev
 
@@ -16,7 +17,7 @@ COPY --from=alpine /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=alpine /etc/passwd /etc/passwd
 
 
-USER nobody
+USER 9999
 COPY --from=build-env /go/src/github.com/fairwindsops/rbac-manager/rbac-manager /
 
 ENTRYPOINT ["/rbac-manager"]

--- a/deploy/all.yaml
+++ b/deploy/all.yaml
@@ -158,7 +158,7 @@ spec:
       serviceAccountName: rbac-manager
       containers:
       - name: rbac-manager
-        image: "quay.io/reactiveops/rbac-manager:v0.9.2"
+        image: "quay.io/reactiveops/rbac-manager:v0.9.3"
         imagePullPolicy: Always
         # these liveness probes use the metrics endpoint
         readinessProbe:
@@ -180,7 +180,6 @@ spec:
           periodSeconds: 10
           failureThreshold: 3
         securityContext:
-          runAsUser: 1200
           allowPrivilegeEscalation: false
           privileged: false
           readOnlyRootFilesystem: true


### PR DESCRIPTION
This should fix #126

I removed the `runAsUser` from the manifest because the docs [here](https://kubernetes.io/docs/concepts/policy/pod-security-policy/#users-and-groups) mention this:
>MustRunAsNonRoot - Requires that the pod be submitted with a non-zero runAsUser or have the USER directive defined (using a numeric UID) in the image.

So I didn't think both were necessary. I'll make a similar change to the chart if necessary once this is merged and we tag 0.9.3