### PR TITLE
adjusting circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  rok8s-scripts: fairwinds/rok8s-scripts@9.4.0
+  rok8s-scripts: fairwinds/rok8s-scripts@11
 
 references:
   docker_build_and_push: &docker_build_and_push
@@ -79,4 +79,10 @@ workflows:
             branches:
               ignore: /.*/
             tags:
-              ignore: /^testing-.*/
+              only: /^v.*/
+      - rok8s-scripts/github_release:
+          filters:
+            branches:
+              ignore: /.*/
+            tags:
+              only: /^v.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,6 +81,8 @@ workflows:
             tags:
               only: /^v.*/
       - rok8s-scripts/github_release:
+          requires:
+            - release
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
- use newer rok8s-scripts orb
- automatically populate release info in github
- only run release jobs on `/^v.*/` tags instead of any tag that is not `/^testing/`