### PR TITLE
Reduce api-server load for namespace list actions

### DIFF
--- a/pkg/reconciler/reconciler.go
+++ b/pkg/reconciler/reconciler.go
@@ -78,6 +78,12 @@ func (r *Reconciler) ReconcileOwners(ownerRefs []metav1.OwnerReference, kind str
 	mux.Lock()
 	defer mux.Unlock()
 
+	namespaces, err := r.Clientset.CoreV1().Namespaces().List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		logrus.Debug("Error listing namespaces")
+		return err
+	}
+
 	for _, ownerRef := range ownerRefs {
 		if ownerRef.Kind == "RBACDefinition" {
 			rbacDef, err := kube.GetRbacDefinition(ownerRef.Name)
@@ -93,7 +99,7 @@ func (r *Reconciler) ReconcileOwners(ownerRefs []metav1.OwnerReference, kind str
 			}
 
 			if kind == "RoleBinding" {
-				p.parseRoleBindings(&rbacDef)
+				p.parseRoleBindings(&rbacDef, namespaces)
 				return r.reconcileRoleBindings(&p.parsedRoleBindings)
 			} else if kind == "ClusterRoleBinding" {
 				p.parseClusterRoleBindings(&rbacDef)


### PR DESCRIPTION
When trying to validate rolebindings with namespace labels, the operation is very heavy when requesting namespaces with a label selector if you have a large number of namespaces, and or a large number of rbac definitions.

This PR changes that functionality, to retrieve all namespaces and then perform the label selector matching client side.

We have observed a 4x reduction in api calls for retrieving namespaces.