### PR TITLE
Correct Helm install example

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -84,7 +84,7 @@ RBAC Manager is simple to install with either the [Helm chart](https://github.co
 
 ```
 helm repo add fairwinds-stable https://charts.fairwinds.com/stable
-helm install fairwinds-stable/rbac-manager --name rbac-manager --namespace rbac-manager
+helm install fairwinds-stable/rbac-manager --name rbac-manager --namespace rbac-manager --create-namespace
 ```
 
 ```


### PR DESCRIPTION
Helm requires `--create-namespace` flag in order to create a new namespace.