### PR TITLE
Fix an issue where we don't return errors

### DIFF
--- a/pkg/controller/rbacdefinition.go
+++ b/pkg/controller/rbacdefinition.go
@@ -77,6 +77,7 @@ func (r *ReconcileRBACDefinition) Reconcile(ctx context.Context, request reconci
 	err = rdr.Reconcile(rbacDef)
 	if err != nil {
 		metrics.ErrorCounter.Inc()
+		return reconcile.Result{}, err
 	}
 
 	return reconcile.Result{}, nil


### PR DESCRIPTION
Discovered this while investigating #321.

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
This error wasn't getting returned, so we were missing important info regarding problems with the rbacdefinition. 

### What changes did you make?
Return the error
### What alternative solution should we consider, if any?