### PR TITLE
Support automountServiceAccountToken in Service Accounts

### DIFF
--- a/deploy/2_crd.yaml
+++ b/deploy/2_crd.yaml
@@ -83,6 +83,8 @@ spec:
                     items:
                       type: object
                       properties:
+                        automountServiceAccountToken:
+                          type: boolean
                         imagePullSecrets:
                           type: array
                           items:

--- a/examples/rbacdefinition-everything.yaml
+++ b/examples/rbacdefinition-everything.yaml
@@ -30,6 +30,9 @@ rbacBindings:
       - kind: ServiceAccount
         name: example
         namespace: default
+        imagePullSecrets:
+          - robot-secret
+        automountServiceAccountToken: false
     clusterRoleBindings:
       - clusterRole: view
     roleBindings:

--- a/pkg/apis/rbacmanager/v1beta1/rbacdefinition_types.go
+++ b/pkg/apis/rbacmanager/v1beta1/rbacdefinition_types.go
@@ -24,7 +24,8 @@ import (
 // Subject is an expansion on the rbacv1.Subject to allow definition of ImagePullSecrets for a Service Account
 type Subject struct {
 	rbacv1.Subject
-	ImagePullSecrets []string `json:"imagePullSecrets"`
+	ImagePullSecrets             []string `json:"imagePullSecrets"`
+	AutomountServiceAccountToken *bool    `json:"automountServiceAccountToken,omitempty"`
 }
 
 // RBACBinding is a specification for a RBACBinding resource

--- a/pkg/reconciler/cases_test.go
+++ b/pkg/reconciler/cases_test.go
@@ -1,0 +1,100 @@
+// Copyright 2018 FairwindsOps Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package reconciler
+
+import (
+	rbacmanagerv1beta1 "github.com/fairwindsops/rbac-manager/pkg/apis/rbacmanager/v1beta1"
+	v1 "k8s.io/api/core/v1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var trueVal bool = true
+var falseVal bool = false
+
+// Parse Subject into ServiceAccount
+var saTestCases = []struct {
+	name     string
+	given    []rbacmanagerv1beta1.Subject
+	expected []v1.ServiceAccount
+}{
+	{
+		"AutomountServiceAccountToken is true",
+		[]rbacmanagerv1beta1.Subject{{
+			Subject:                      rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot", Namespace: "default"},
+			AutomountServiceAccountToken: &trueVal,
+		}},
+		[]v1.ServiceAccount{{
+			ObjectMeta:                   metav1.ObjectMeta{Name: "robot", Namespace: "default"},
+			AutomountServiceAccountToken: &trueVal,
+		}},
+	},
+	{
+		"AutomountServiceAccountToken is false",
+		[]rbacmanagerv1beta1.Subject{{
+			Subject:                      rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot", Namespace: "default"},
+			AutomountServiceAccountToken: &falseVal,
+		}},
+		[]v1.ServiceAccount{{
+			ObjectMeta:                   metav1.ObjectMeta{Name: "robot", Namespace: "default"},
+			AutomountServiceAccountToken: &falseVal,
+		}},
+	},
+	{
+		"AutomountServiceAccountToken is empty",
+		[]rbacmanagerv1beta1.Subject{{
+			Subject: rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot", Namespace: "default"},
+		}},
+		[]v1.ServiceAccount{{
+			ObjectMeta:                   metav1.ObjectMeta{Name: "robot", Namespace: "default"},
+			AutomountServiceAccountToken: nil,
+		}},
+	},
+	{
+		"ImagePullSecrets is empty",
+		[]rbacmanagerv1beta1.Subject{{
+			Subject:          rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot", Namespace: "default"},
+			ImagePullSecrets: []string{},
+		}},
+		[]v1.ServiceAccount{{
+			ObjectMeta:       metav1.ObjectMeta{Name: "robot", Namespace: "default"},
+			ImagePullSecrets: nil,
+		}},
+	},
+	{
+		"ImagePullSecrets is not empty",
+		[]rbacmanagerv1beta1.Subject{{
+			Subject:          rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot", Namespace: "default"},
+			ImagePullSecrets: []string{"secret-z", "secret-a"},
+		}},
+		[]v1.ServiceAccount{{
+			ObjectMeta:       metav1.ObjectMeta{Name: "robot", Namespace: "default"},
+			ImagePullSecrets: []v1.LocalObjectReference{{Name: "secret-a"}, {Name: "secret-z"}},
+		}},
+	},
+	{
+		"Parsing multiple Service Accounts",
+		[]rbacmanagerv1beta1.Subject{
+			{Subject: rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot-a", Namespace: "default"}},
+			{Subject: rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot-a", Namespace: "non-default"}},
+			{Subject: rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot-z", Namespace: "default"}},
+		},
+		[]v1.ServiceAccount{
+			{ObjectMeta: metav1.ObjectMeta{Name: "robot-z", Namespace: "default"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "robot-a", Namespace: "non-default"}},
+			{ObjectMeta: metav1.ObjectMeta{Name: "robot-a", Namespace: "default"}},
+		},
+	},
+}

--- a/pkg/reconciler/parser.go
+++ b/pkg/reconciler/parser.go
@@ -77,7 +77,8 @@ func (p *Parser) parseRBACBinding(rbacBinding rbacmanagerv1beta1.RBACBinding, na
 					OwnerReferences: p.ownerRefs,
 					Labels:          kube.Labels,
 				},
-				ImagePullSecrets: pullsecrets,
+				ImagePullSecrets:             pullsecrets,
+				AutomountServiceAccountToken: requestedSubject.AutomountServiceAccountToken,
 			})
 		}
 	}

--- a/pkg/reconciler/parser_test.go
+++ b/pkg/reconciler/parser_test.go
@@ -284,6 +284,24 @@ func TestManagerToRbacSubjects(t *testing.T) {
 	assert.ElementsMatch(t, expected, actual, "expected subjects to match")
 }
 
+func TestServiceAccountParsing(t *testing.T) {
+	for _, n := range saTestCases {
+		t.Run(n.name, func(t *testing.T) {
+			client := fake.NewSimpleClientset()
+			rbacDef := rbacmanagerv1beta1.RBACDefinition{}
+			rbacDef.Name = "rbac-config"
+
+			rbacDef.RBACBindings = []rbacmanagerv1beta1.RBACBinding{{
+				Name:                "devs",
+				Subjects:            n.given,
+				ClusterRoleBindings: []rbacmanagerv1beta1.ClusterRoleBinding{},
+			}}
+
+			newParseTest(t, client, rbacDef, []rbacv1.RoleBinding{}, []rbacv1.ClusterRoleBinding{}, n.expected)
+		})
+	}
+}
+
 func newParseTest(t *testing.T, client *fake.Clientset, rbacDef rbacmanagerv1beta1.RBACDefinition, expectedRb []rbacv1.RoleBinding, expectedCrb []rbacv1.ClusterRoleBinding, expectedSa []corev1.ServiceAccount) {
 	p := Parser{Clientset: client}
 
@@ -353,12 +371,14 @@ func expectParsedSA(t *testing.T, p Parser, expected []corev1.ServiceAccount) {
 		for _, actualSa := range p.parsedServiceAccounts {
 			if actualSa.Name == expectedSa.Name && expectedSa.Namespace == actualSa.Namespace {
 				matchFound = true
+				assert.ElementsMatch(t, actualSa.ImagePullSecrets, expectedSa.ImagePullSecrets)
+				assert.EqualValues(t, expectedSa.AutomountServiceAccountToken, actualSa.AutomountServiceAccountToken)
 				break
 			}
 		}
 
 		if !matchFound {
-			t.Fatalf("Matching service account not found for %v", expectedSa.Name)
+			t.Fatalf("Matching service account not found for %v in namespace %v", expectedSa.Name, expectedSa.Namespace)
 		}
 	}
 }

--- a/pkg/reconciler/parser_test.go
+++ b/pkg/reconciler/parser_test.go
@@ -378,7 +378,7 @@ func expectParsedSA(t *testing.T, p Parser, expected []corev1.ServiceAccount) {
 		}
 
 		if !matchFound {
-			t.Fatalf("Matching service account not found for %v in namespace %v", expectedSa.Name, expectedSa.Namespace)
+			t.Fatalf("Matching service account not found for %s in namespace %s", expectedSa.Name, expectedSa.Namespace)
 		}
 	}
 }


### PR DESCRIPTION
This PR fixes #132

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
See https://github.com/FairwindsOps/rbac-manager/issues/132

### What changes did you make?
- added optional `automountServiceAccountToken` property
- unit tests to cover all (?) possible happy-path cases to parse `ServiceAccount`

### What alternative solution should we consider, if any?
-
