### PR TITLE
feat(kube-1-24): create and ref secrets and add email key as required

### DIFF
--- a/deploy/2_crd.yaml
+++ b/deploy/2_crd.yaml
@@ -99,9 +99,12 @@ spec:
                           type: string
                         namespace:
                           type: string
+                        email:
+                          type: string
                       required:
                         - name
                         - kind
+                        - email
                     type: array
                 required:
                   - name

--- a/pkg/apis/rbacmanager/v1beta1/rbacdefinition_types.go
+++ b/pkg/apis/rbacmanager/v1beta1/rbacdefinition_types.go
@@ -26,6 +26,7 @@ type Subject struct {
 	rbacv1.Subject
 	ImagePullSecrets             []string `json:"imagePullSecrets"`
 	AutomountServiceAccountToken *bool    `json:"automountServiceAccountToken,omitempty"`
+	Email                        string   `json:"email"`
 }
 
 // RBACBinding is a specification for a RBACBinding resource

--- a/pkg/kube/kube.go
+++ b/pkg/kube/kube.go
@@ -18,6 +18,8 @@ package kube
 
 import (
 	"os"
+	"regexp"
+	"strconv"
 
 	"github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -54,4 +56,30 @@ func GetClientsetOrDie() *kubernetes.Clientset {
 	}
 
 	return clientset
+}
+
+// GetKubeVersion returns the major and minor version of the Kubernetes cluster
+func GetKubeVersion() (major, minor int) {
+	clientset := GetClientsetOrDie()
+	version, err := clientset.ServerVersion()
+	if err != nil {
+		logrus.Error(err, "unable to get Kubernetes version")
+		os.Exit(1)
+	}
+
+	reVersion := regexp.MustCompile(`^\d+`)
+	version.Major = reVersion.FindString(version.Major)
+	version.Minor = reVersion.FindString(version.Minor)
+
+	majorInt, err := strconv.Atoi(version.Major)
+	if err != nil {
+		logrus.Error(err, "unable to convert server major version to int")
+		os.Exit(1)
+	}
+	minorInt, err := strconv.Atoi(version.Minor)
+	if err != nil {
+		logrus.Error(err, "unable to convert server minor version to int")
+		os.Exit(1)
+	}
+	return majorInt, minorInt
 }

--- a/pkg/reconciler/parser.go
+++ b/pkg/reconciler/parser.go
@@ -76,6 +76,7 @@ func (p *Parser) parseRBACBinding(rbacBinding rbacmanagerv1beta1.RBACBinding, na
 					Namespace:       requestedSubject.Namespace,
 					OwnerReferences: p.ownerRefs,
 					Labels:          kube.Labels,
+					Annotations:     map[string]string{"email": requestedSubject.Email},
 				},
 				ImagePullSecrets:             pullsecrets,
 				AutomountServiceAccountToken: requestedSubject.AutomountServiceAccountToken,


### PR DESCRIPTION
This PR fixes 
Nothing...

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Better usage rbac-manager as i think :)

### What changes did you make?
- Add Kubernetes >= 1.24 support (creating secret after creating serviceAccount and ref it to serviceAccount)
- Added required field email (add email as annotation to serviceAccount and Secret for friendly search)

### What alternative solution should we consider, if any?
I don't know :)
