### PR TITLE
Sa pull secret

### DIFF
--- a/pkg/reconciler/matcher.go
+++ b/pkg/reconciler/matcher.go
@@ -15,7 +15,7 @@
 package reconciler
 
 import (
-	"reflect"
+	"strings"
 
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -53,13 +53,36 @@ func rbMatches(existingRB *rbacv1.RoleBinding, requestedRB *rbacv1.RoleBinding) 
 }
 
 func saMatches(existingSA *v1.ServiceAccount, requestedSA *v1.ServiceAccount) bool {
-	if metaMatches(&existingSA.ObjectMeta, &requestedSA.ObjectMeta) {
-		if len(requestedSA.ImagePullSecrets) < 1 && existingSA.ImagePullSecrets == nil {
-			return true
-		}
-		return reflect.DeepEqual(&existingSA.ImagePullSecrets, &requestedSA.ImagePullSecrets)
+	if !metaMatches(&existingSA.ObjectMeta, &requestedSA.ObjectMeta) {
+		return false
 	}
-	return false
+	requestedSAManagedPullSecretsAnnotation, exists := requestedSA.Annotations[ManagedPullSecretsAnnotationKey]
+	if !exists {
+		return false
+	}
+
+	existingSAManagedPullSecretsAnnotation, exists := existingSA.Annotations[ManagedPullSecretsAnnotationKey]
+	if !exists {
+		return false
+	}
+
+	if requestedSAManagedPullSecretsAnnotation != existingSAManagedPullSecretsAnnotation {
+		return false
+	}
+
+	for _, requestedSAManagedPullSecret := range strings.Split(requestedSAManagedPullSecretsAnnotation, ",") {
+		matches := false
+		for _, existingSAPullSecret := range existingSA.ImagePullSecrets {
+			if requestedSAManagedPullSecret == existingSAPullSecret.Name {
+				matches = true
+			}
+		}
+		if !matches {
+			return false
+		}
+	}
+
+	return true
 }
 
 func metaMatches(existingMeta *metav1.ObjectMeta, requestedMeta *metav1.ObjectMeta) bool {

--- a/pkg/reconciler/matcher.go
+++ b/pkg/reconciler/matcher.go
@@ -15,8 +15,6 @@
 package reconciler
 
 import (
-	"strings"
-
 	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -70,10 +68,10 @@ func saMatches(existingSA *v1.ServiceAccount, requestedSA *v1.ServiceAccount) bo
 		return false
 	}
 
-	for _, requestedSAManagedPullSecret := range strings.Split(requestedSAManagedPullSecretsAnnotation, ",") {
+	for _, requestedSAImagePullSecrets := range requestedSA.ImagePullSecrets {
 		matches := false
 		for _, existingSAPullSecret := range existingSA.ImagePullSecrets {
-			if requestedSAManagedPullSecret == existingSAPullSecret.Name {
+			if requestedSAImagePullSecrets.Name == existingSAPullSecret.Name {
 				matches = true
 			}
 		}

--- a/pkg/reconciler/matcher_test.go
+++ b/pkg/reconciler/matcher_test.go
@@ -239,16 +239,16 @@ func TestSAMatches(t *testing.T) {
 		t.Fatal("SA 1 should not match SA 3")
 	}
 
-	if !saMatches(&sa1, &sa4) {
-		t.Fatal("SA 1 should match SA 4")
+	if !saMatches(&sa4, &sa1) {
+		t.Fatal("SA 4 should match SA 1")
 	}
 
 	if saMatches(&sa1, &sa5) {
 		t.Fatal("SA 1 should not match SA 3")
 	}
 
-	if saMatches(&sa3, &sa4) {
-		t.Fatal("SA 3 should not match SA 4")
+	if saMatches(&sa4, &sa3) {
+		t.Fatal("SA 4 should not match SA 3")
 	}
 
 	if saMatches(&sa5, &sa3) {

--- a/pkg/reconciler/matcher_test.go
+++ b/pkg/reconciler/matcher_test.go
@@ -17,6 +17,7 @@ package reconciler
 import (
 	"testing"
 
+	v1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -180,5 +181,81 @@ func TestRbMatches(t *testing.T) {
 
 	if !rbMatches(&rb3, &rb3) {
 		t.Fatal("RB 3 should match RB 3")
+	}
+}
+
+func TestSAMatches(t *testing.T) {
+	sa1 := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "sample-name",
+			Namespace:       "sample",
+			OwnerReferences: generateOwnerReferences("foo"),
+			Annotations:     map[string]string{ManagedPullSecretsAnnotationKey: "fairwinds"},
+		},
+		ImagePullSecrets: []v1.LocalObjectReference{{Name: "fairwinds"}},
+	}
+	sa2 := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "sample-name",
+			Namespace:       "sample",
+			OwnerReferences: generateOwnerReferences("foo"),
+			Annotations:     map[string]string{ManagedPullSecretsAnnotationKey: "fairwinds"},
+		},
+		ImagePullSecrets: []v1.LocalObjectReference{{Name: "fairwinds"}},
+	}
+	sa3 := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "sample-name",
+			Namespace:       "sample",
+			OwnerReferences: generateOwnerReferences("foo"),
+			Annotations:     map[string]string{ManagedPullSecretsAnnotationKey: "fairwinds,another"},
+		},
+		ImagePullSecrets: []v1.LocalObjectReference{{Name: "fairwinds"}, {Name: "another"}},
+	}
+	sa4 := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "sample-name",
+			Namespace:       "sample",
+			OwnerReferences: generateOwnerReferences("foo"),
+			Annotations:     map[string]string{ManagedPullSecretsAnnotationKey: "fairwinds"},
+		},
+		ImagePullSecrets: []v1.LocalObjectReference{{Name: "fairwinds"}, {Name: "extra"}},
+	}
+	sa5 := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "sample-name",
+			Namespace:       "sample",
+			OwnerReferences: generateOwnerReferences("foo"),
+			Annotations:     map[string]string{ManagedPullSecretsAnnotationKey: "fairwinds,another"},
+		},
+		ImagePullSecrets: []v1.LocalObjectReference{{Name: "fairwinds"}},
+	}
+
+	if !saMatches(&sa1, &sa2) {
+		t.Fatal("SA 1 should match SA 2")
+	}
+
+	if saMatches(&sa1, &sa3) {
+		t.Fatal("SA 1 should not match SA 3")
+	}
+
+	if !saMatches(&sa1, &sa4) {
+		t.Fatal("SA 1 should match SA 4")
+	}
+
+	if saMatches(&sa1, &sa5) {
+		t.Fatal("SA 1 should not match SA 3")
+	}
+
+	if saMatches(&sa3, &sa4) {
+		t.Fatal("SA 3 should not match SA 4")
+	}
+
+	if saMatches(&sa5, &sa3) {
+		t.Fatal("SA 5 should not match SA 3")
+	}
+
+	if saMatches(&sa5, &sa4) {
+		t.Fatal("SA 5 should not match SA 4")
 	}
 }


### PR DESCRIPTION
This PR fixes #417

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
Change the default behaviour of service account pull secrets to support adding extra ones, supporting global pull secrets on OKD/OCP and the ones manually added

### What changes did you make?
The SA matching logic is updated so it matches SAs with the same metadata and if all of the desired pull secrets are present on the existing SA.

### What alternative solution should we consider, if any?
-
