### PR TITLE
feat: allow adding annotations to ServiceAccounts

### DIFF
--- a/deploy/2_crd.yaml
+++ b/deploy/2_crd.yaml
@@ -99,6 +99,15 @@ spec:
                           type: string
                         namespace:
                           type: string
+                        metadata:
+                          type: object
+                          properties:
+                            annotations:
+                              type: object
+                              additionalProperties: true
+                            labels:
+                              type: object
+                              additionalProperties: true
                       required:
                         - name
                         - kind

--- a/pkg/apis/rbacmanager/v1beta1/rbacdefinition_types.go
+++ b/pkg/apis/rbacmanager/v1beta1/rbacdefinition_types.go
@@ -24,8 +24,9 @@ import (
 // Subject is an expansion on the rbacv1.Subject to allow definition of ImagePullSecrets for a Service Account
 type Subject struct {
 	rbacv1.Subject               `json:",inline"`
-	ImagePullSecrets             []string `json:"imagePullSecrets"`
-	AutomountServiceAccountToken *bool    `json:"automountServiceAccountToken,omitempty"`
+	Metadata                     *metav1.ObjectMeta `json:"metadata,omitempty"`
+	ImagePullSecrets             []string           `json:"imagePullSecrets"`
+	AutomountServiceAccountToken *bool              `json:"automountServiceAccountToken,omitempty"`
 }
 
 // RBACBinding is a specification for a RBACBinding resource

--- a/pkg/reconciler/cases_test.go
+++ b/pkg/reconciler/cases_test.go
@@ -80,7 +80,7 @@ var saTestCases = []struct {
 			ImagePullSecrets: []string{"secret-z", "secret-a"},
 		}},
 		[]v1.ServiceAccount{{
-			ObjectMeta:       metav1.ObjectMeta{Name: "robot", Namespace: "default"},
+			ObjectMeta:       metav1.ObjectMeta{Name: "robot", Namespace: "default", Annotations: map[string]string{ManagedPullSecretsAnnotationKey: "secret-z,secret-a"}},
 			ImagePullSecrets: []v1.LocalObjectReference{{Name: "secret-a"}, {Name: "secret-z"}},
 		}},
 	},
@@ -96,5 +96,59 @@ var saTestCases = []struct {
 			{ObjectMeta: metav1.ObjectMeta{Name: "robot-a", Namespace: "non-default"}},
 			{ObjectMeta: metav1.ObjectMeta{Name: "robot-a", Namespace: "default"}},
 		},
+	},
+	{
+		"Annotations are passed",
+		[]rbacmanagerv1beta1.Subject{{
+			Subject:  rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot", Namespace: "default"},
+			Metadata: &metav1.ObjectMeta{Annotations: map[string]string{"annotation-a": "annotation-value-a", "annotation-b": "annotation-value-b"}},
+		}},
+		[]v1.ServiceAccount{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "robot",
+				Namespace:   "default",
+				Annotations: map[string]string{"annotation-a": "annotation-value-a", "annotation-b": "annotation-value-b"},
+			},
+		}},
+	},
+	{
+		"RBAC manager annotations may not be set directly",
+		[]rbacmanagerv1beta1.Subject{{
+			Subject:  rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot", Namespace: "default"},
+			Metadata: &metav1.ObjectMeta{Annotations: map[string]string{ManagedPullSecretsAnnotationKey: "some-explicit-value", "annotation-a": "annotation-value-a", "annotation-b": "annotation-value-b"}},
+		}},
+		[]v1.ServiceAccount{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:        "robot",
+				Namespace:   "default",
+				Annotations: map[string]string{"annotation-a": "annotation-value-a", "annotation-b": "annotation-value-b"},
+			},
+		}},
+	},
+	{
+		"RBAC manager annotations may not be changed by overwriting it",
+		[]rbacmanagerv1beta1.Subject{{
+			Subject:          rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot", Namespace: "default"},
+			Metadata:         &metav1.ObjectMeta{Annotations: map[string]string{ManagedPullSecretsAnnotationKey: "some-explicit-value"}},
+			ImagePullSecrets: []string{"secret-z", "secret-a"},
+		}},
+		[]v1.ServiceAccount{{
+			ObjectMeta:       metav1.ObjectMeta{Name: "robot", Namespace: "default", Annotations: map[string]string{ManagedPullSecretsAnnotationKey: "secret-z,secret-a"}},
+			ImagePullSecrets: []v1.LocalObjectReference{{Name: "secret-a"}, {Name: "secret-z"}},
+		}},
+	},
+	{
+		"Labels are passed",
+		[]rbacmanagerv1beta1.Subject{{
+			Subject:  rbacv1.Subject{Kind: rbacv1.ServiceAccountKind, Name: "robot", Namespace: "default"},
+			Metadata: &metav1.ObjectMeta{Labels: map[string]string{"label-a": "label-value-a", "label-b": "label-value-b"}},
+		}},
+		[]v1.ServiceAccount{{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "robot",
+				Namespace: "default",
+				Labels:    map[string]string{"label-a": "label-value-a", "label-b": "label-value-b"},
+			},
+		}},
 	},
 }

--- a/pkg/reconciler/matcher.go
+++ b/pkg/reconciler/matcher.go
@@ -96,6 +96,18 @@ func metaMatches(existingMeta *metav1.ObjectMeta, requestedMeta *metav1.ObjectMe
 		return false
 	}
 
+	for labelKey, labelValue := range requestedMeta.Labels {
+		if existingMeta.Labels[labelKey] != labelValue {
+			return false
+		}
+	}
+
+	for annotationKey, annotationValue := range requestedMeta.Annotations {
+		if existingMeta.Annotations[annotationKey] != annotationValue {
+			return false
+		}
+	}
+
 	return true
 }
 

--- a/pkg/reconciler/matcher_test.go
+++ b/pkg/reconciler/matcher_test.go
@@ -230,6 +230,30 @@ func TestSAMatches(t *testing.T) {
 		},
 		ImagePullSecrets: []v1.LocalObjectReference{{Name: "fairwinds"}},
 	}
+	sa6 := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "sample-name",
+			Namespace:       "sample",
+			OwnerReferences: generateOwnerReferences("foo"),
+			Annotations:     map[string]string{"annotation-a": "annotation-value-a"},
+		},
+	}
+	sa7 := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "sample-name",
+			Namespace:       "sample",
+			OwnerReferences: generateOwnerReferences("foo"),
+			Labels:          map[string]string{"label-a": "label-value-a"},
+		},
+	}
+	sa8 := v1.ServiceAccount{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            "sample-name",
+			Namespace:       "sample",
+			OwnerReferences: generateOwnerReferences("foo"),
+			Labels:          map[string]string{"label-a": "label-value-a", "label-b": "label-value-b"},
+		},
+	}
 
 	if !saMatches(&sa1, &sa2) {
 		t.Fatal("SA 1 should match SA 2")
@@ -247,6 +271,10 @@ func TestSAMatches(t *testing.T) {
 		t.Fatal("SA 1 should not match SA 3")
 	}
 
+	if saMatches(&sa1, &sa6) {
+		t.Fatal("SA 1 should not match SA 6")
+	}
+
 	if saMatches(&sa4, &sa3) {
 		t.Fatal("SA 4 should not match SA 3")
 	}
@@ -257,5 +285,17 @@ func TestSAMatches(t *testing.T) {
 
 	if saMatches(&sa5, &sa4) {
 		t.Fatal("SA 5 should not match SA 4")
+	}
+
+	if saMatches(&sa5, &sa6) {
+		t.Fatal("SA 5 should not match SA 6")
+	}
+
+	if saMatches(&sa6, &sa7) {
+		t.Fatal("SA 6 should not match SA 7")
+	}
+
+	if saMatches(&sa7, &sa8) {
+		t.Fatal("SA 7 should not match SA 8")
 	}
 }

--- a/pkg/reconciler/parser_test.go
+++ b/pkg/reconciler/parser_test.go
@@ -373,6 +373,9 @@ func expectParsedSA(t *testing.T, p Parser, expected []corev1.ServiceAccount) {
 				matchFound = true
 				assert.ElementsMatch(t, actualSa.ImagePullSecrets, expectedSa.ImagePullSecrets)
 				assert.EqualValues(t, expectedSa.AutomountServiceAccountToken, actualSa.AutomountServiceAccountToken)
+				if !metaMatches(&actualSa.ObjectMeta, &expectedSa.ObjectMeta) {
+					t.Fatal("ObjectMeta is not matching")
+				}
 				break
 			}
 		}


### PR DESCRIPTION
This PR fixes #425 

## Checklist
* [x] I have signed the CLA
* [x] I have updated/added any relevant documentation

## Description
### What's the goal of this PR?
This PR allows to add labels and annotations to ServiceAccounts created and managed by rbac-manager.

### What changes did you make?
The changes include:
* an API extension to allow labels and annotations optionally
* parser and matcher changes to pass the metadata to the created objects

### What alternative solution should we consider, if any?
-