### PR TITLE
fix: convert namespace labels to a label Set instead of merging the map with itself

### DIFF
--- a/pkg/reconciler/parser.go
+++ b/pkg/reconciler/parser.go
@@ -173,7 +173,7 @@ func (p *Parser) parseRoleBinding(
 
 		for _, namespace := range namespaces.Items {
 			// Lazy way to marshal map[] of labels in to a Set, which we can then match on.
-			if selector.Matches(labels.Merge(namespace.Labels, namespace.Labels)) {
+			if selector.Matches(labels.Set(namespace.Labels)) {
 				slog.Debug("Adding Role Binding With Dynamic Namespace", "namespace", namespace.Name)
 
 				om := objectMeta

--- a/pkg/reconciler/parser_test.go
+++ b/pkg/reconciler/parser_test.go
@@ -302,6 +302,52 @@ func TestServiceAccountParsing(t *testing.T) {
 	}
 }
 
+// TestParseLabelsUnlabeledNamespace guards the namespace-label to label.Set
+// conversion in parseRoleBinding against a namespace whose Labels map is nil.
+// A nil map must convert to an empty Set that simply fails to match the
+// selector, rather than panicking or being treated as a match, so an
+// unlabeled namespace is left out of the selected bindings.
+func TestParseLabelsUnlabeledNamespace(t *testing.T) {
+	client := fake.NewSimpleClientset()
+	rbacDef := rbacmanagerv1beta1.RBACDefinition{}
+	rbacDef.Name = "rbac-config"
+
+	createNamespace(t, client, "web", map[string]string{"team": "devs"})
+	createNamespace(t, client, "unlabeled", nil)
+
+	rbacDef.RBACBindings = []rbacmanagerv1beta1.RBACBinding{{
+		Name: "devs",
+		Subjects: []rbacmanagerv1beta1.Subject{{
+			Subject: rbacv1.Subject{
+				Kind: rbacv1.UserKind,
+				Name: "sue",
+			},
+		}},
+		RoleBindings: []rbacmanagerv1beta1.RoleBinding{{
+			NamespaceSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"team": "devs"},
+			},
+			ClusterRole: "edit",
+		}},
+	}}
+
+	// Only the labeled namespace matches; the unlabeled one is excluded.
+	newParseTest(t, client, rbacDef, []rbacv1.RoleBinding{{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "rbac-config-devs-edit",
+			Namespace: "web",
+		},
+		RoleRef: rbacv1.RoleRef{
+			Kind: "ClusterRole",
+			Name: "edit",
+		},
+		Subjects: []rbacv1.Subject{{
+			Kind: rbacv1.UserKind,
+			Name: "sue",
+		}},
+	}}, []rbacv1.ClusterRoleBinding{}, []corev1.ServiceAccount{})
+}
+
 func newParseTest(t *testing.T, client *fake.Clientset, rbacDef rbacmanagerv1beta1.RBACDefinition, expectedRb []rbacv1.RoleBinding, expectedCrb []rbacv1.ClusterRoleBinding, expectedSa []corev1.ServiceAccount) {
 	p := Parser{Clientset: client}
 


### PR DESCRIPTION
parseRoleBinding built the label selector match by calling labels.Merge(namespace.Labels, namespace.Labels), merging the namespace label map with a copy of itself. That is a confused artifact, not a real merge, and the second argument exists only to satisfy the helper signature. labels.Set converts a map directly to a labels.Set, which is the documented way to build the Set that selector.Matches expects. Behavior is unchanged for the existing namespace-selector tests; the call just says what it means.